### PR TITLE
Feat/UtilArticle: Article관련 유틸함수 구현 

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -4,5 +4,7 @@ declare interface Article {
   title: string;
   categories: string[];
   bookmark: boolean;
-  readAt?: Date;
+  readAt?: string;
+  thumbnail: string;
+  description: string;
 }

--- a/src/utils/article.ts
+++ b/src/utils/article.ts
@@ -1,0 +1,53 @@
+import { getItem, setItem } from '@utils/localstorage';
+
+const ARTICLE_KEY = 'articles';
+
+export const addArticle = (newArticle: Omit<Article, 'id' | 'bookmark'>) => {
+  const articles = getArticles();
+
+  const article: Article = {
+    ...newArticle,
+    id: articles.length ? articles[articles.length - 1].id : 0,
+    bookmark: false,
+  };
+
+  setItem(ARTICLE_KEY, [...articles, article]);
+};
+
+const changeArticleProperty = (
+  targetId: number,
+  callback: (targetArticle: Article) => void,
+) => {
+  const articles = getArticles();
+  const targetArticle = articles.find(({ id }) => id === targetId);
+
+  if (!targetArticle) throw new Error('찾는 아티클이 없습니다. 나쁜 유저 🚨🚨');
+  console.log(targetArticle);
+
+  callback(targetArticle);
+  setItem(ARTICLE_KEY, [...articles, targetArticle]);
+};
+
+export const bookmarkArticle = (targetId: number) =>
+  changeArticleProperty(targetId, (article) => {
+    article.bookmark = true;
+  });
+
+export const readArticle = (targetId: number) =>
+  changeArticleProperty(targetId, (article) => {
+    article.readAt = new Date().toString();
+  });
+
+export const getArticles = (predicate?: (article: Article) => boolean) => {
+  const articles = getItem<Article[]>(ARTICLE_KEY) ?? [];
+  return predicate ? articles.filter(predicate) : articles;
+};
+
+export const getRandomArticle = (predicate?: (article: Article) => boolean) => {
+  const filteredArticles = getArticles(predicate);
+
+  if (!filteredArticles) return null;
+
+  const randomIndex = Math.floor(Math.random() * filteredArticles.length);
+  return filteredArticles[randomIndex];
+};

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -1,0 +1,12 @@
+export const getItem = <T>(key: string) => {
+  const item = localStorage.getItem(key);
+  return item ? (JSON.parse(item) as T) : null;
+};
+
+export const setItem = <T>(key: string, data: T) => {
+  localStorage.setItem(key, JSON.stringify(data));
+};
+
+export const hasItem = (key: string) => {
+  return getItem(key) !== null;
+};


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes: #16 

## 💫 설명

<!--

- 현재 Pr 설명

-->

- util함수 만들었어요.
  - localStorage에 북마크 이런거 다 만드려다가 나중에 localStorage 떼어버리고 DB달았을 떼 조금 머리아플것 같아서 분리했어요.
  - article 유틸함수에서 다음과 같은 동작들이 가능합니다.
    - `addArticle`
      ```ts
      export const addArticle = (newArticle: Omit<Article, 'id' | 'bookmark'>)
      ```
      - id랑 bookmark가 없는 날것의 정보를 전달해주면 id와 bookmark를 초기화해서 저장합니다.
      - id는 제일 마지막 id에 + 1합니다. 더 좋은 생성 방식이 있다면 알려주세요
    - `bookmarkArticle`
      - targetId만 전달하면 됩니다.
    - `readArticle`
      - targetId만 전달하면 됩니다.
    - `getArticles`
      - filter 조건을 전달할 수 있습니다.
      - 없으면 전체 Articles, 있다면 filteredArticles를 반환합니다.
    - `getRandomArticle`
      - filter 조건을 전달할 수 있습니다.
      - filter 조건이 있다면 filtering 후 랜덤한 Article을 전달합니다.  

## 📷 스크린샷 (Optional)
