### PR TITLE
Feat/bank page: 아티클 목록 페이지 구현 

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -45,19 +45,21 @@ export default Badge;
 const BadgeContainer = styled.div<Omit<BadgeProps, 'children' | 'size'>>(
   ({ theme, color, filled }) => {
     const { color: themeColor } = theme;
-    const { white, primary100 } = themeColor;
+    const { white, primary100, primary200 } = themeColor;
 
     return {
       width: 'fit-content',
       padding: '8px 12px',
       borderRadius: 30,
-      border: filled ? 'none' : `1px solid ${color ?? primary100}`,
+      border: `1px solid ${primary100}`,
       color: filled ? white : color ?? primary100,
       backgroundColor: filled ? color ?? primary100 : 'transparent',
+      cursor: 'pointer',
 
       ':hover': {
-        color: filled ? color ?? primary100 : white,
-        backgroundColor: filled ? 'transparent' : color ?? primary100,
+        border: `1px solid ${primary200}`,
+        color: filled ? white : color ?? primary200,
+        backgroundColor: filled ? color ?? primary200 : 'transparent',
       },
     };
   },

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -11,6 +11,7 @@ interface BadgeProps {
   color?: string;
   filled?: boolean;
   toggle?: boolean;
+  onClick?: () => void;
 }
 
 const Badge = ({
@@ -19,6 +20,7 @@ const Badge = ({
   color,
   filled = true,
   toggle,
+  onClick,
 }: BadgeProps) => {
   const [isFilled, setIsFilled] = useState(filled);
   const onToggle = () => setIsFilled((prev) => !prev);
@@ -26,7 +28,10 @@ const Badge = ({
   const props = {
     color,
     filled: isFilled,
-    onClick: toggle ? onToggle : undefined,
+    onClick: () => {
+      if (toggle) onToggle();
+      if (onClick) onClick();
+    },
   };
 
   return (

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,7 +7,7 @@ import { DefaultProps } from '@utils/types/DefaultProps';
 import { CSSProperties } from 'react';
 
 type ButtonShapeVariant = 'round' | 'square';
-type ButtonThemeVariant = 'light';
+type ButtonThemeVariant = 'light' | 'dark';
 type ButtonVariant =
   | ButtonShapeVariant
   | ButtonThemeVariant

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -1,13 +1,14 @@
 import Flexbox from '@components-layout/Flexbox';
 import { css, useTheme } from '@emotion/react';
 import { DefaultProps } from '@util-types/DefaultProps';
-import { CSSProperties } from 'react';
+import { CSSProperties, useState } from 'react';
 import { MdCheck } from 'react-icons/md';
 
 type CheckboxProps = DefaultProps<HTMLInputElement> & {
   direction?: CSSProperties['flexDirection'];
   label?: string;
   value: string;
+  checked?: boolean;
   onChange?: (checked: boolean) => void;
 };
 
@@ -15,10 +16,13 @@ const Checkbox = ({
   direction = 'row',
   label: checkboxLabel = '',
   value,
+  checked = false,
   onChange,
 }: CheckboxProps) => {
   const { color: themeColor } = useTheme();
   const { white, primary100, gray100 } = themeColor;
+
+  const [isChecked, setIsChecked] = useState<boolean>(checked);
 
   return (
     <Flexbox flexDirection={direction} justifyContent="start">
@@ -29,9 +33,11 @@ const Checkbox = ({
         type="checkbox"
         id={`checkbox_${value}`}
         name={`checkbox_${value}`}
+        checked={isChecked}
         onChange={(e) => {
           if (onChange) {
             onChange(e.target.checked);
+            setIsChecked((isChecked) => !isChecked);
           }
         }}
       />

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -37,8 +37,8 @@ const Checkbox = ({
         onChange={(e) => {
           if (onChange) {
             onChange(e.target.checked);
-            setIsChecked((isChecked) => !isChecked);
           }
+          setIsChecked((isChecked) => !isChecked);
         }}
       />
       <label

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -8,6 +8,7 @@ import { Fragment, MouseEvent, useEffect, useMemo, useState } from 'react';
 
 const BankPage = () => {
   const [articles, setArticles] = useState<Article[] | null>(null);
+  const [selected, setSelected] = useState<number>(0);
   const tabMenu = useMemo(() => ['전체', '부채', '적금', '상환'], []);
 
   useEffect(() => {
@@ -39,6 +40,7 @@ const BankPage = () => {
     }
 
     setArticles(() => storedArticles);
+    setSelected(customTabIndex === undefined ? 0 : +customTabIndex);
   };
 
   return (
@@ -48,7 +50,7 @@ const BankPage = () => {
           <Button
             key={menu}
             text={menu}
-            variant={'light'}
+            variant={selected === idx ? 'dark' : 'light'}
             data-tab-index={idx}
             onClick={handleTabMenu}
           />
@@ -57,10 +59,12 @@ const BankPage = () => {
       <Spacing size={15} />
       <Flexbox justifyContent={'start'}>
         {Object.values(CATEGORY).map((c) => (
-          <Badge key={c}>{c}</Badge>
+          <Badge key={c} outline>
+            {c}
+          </Badge>
         ))}
       </Flexbox>
-      <Spacing size={15} />
+      <Spacing size={20} />
       <Flexbox flexDirection="column">
         {articles &&
           articles.map((article) => {

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -4,6 +4,7 @@ import Checkbox from '@components/Checkbox';
 import Spacing from '@components/Spacing';
 import Flexbox from '@components-layout/Flexbox';
 import { CATEGORY } from '@constants/category';
+import { getArticles, readArticle } from '@utils/article';
 import { Fragment, MouseEvent, useEffect, useMemo, useState } from 'react';
 
 const BankPage = () => {
@@ -21,18 +22,16 @@ const BankPage = () => {
     let storedArticles = JSON.parse(localStorage.getItem('articles') ?? '');
     switch (customTabIndex) {
       case '1':
-        storedArticles = storedArticles.filter(
+        storedArticles = getArticles(
           (article: Article) => article.readAt === undefined,
         );
         break;
       case '2':
-        storedArticles = storedArticles.filter(
-          (article: Article) => article.bookmark,
-        );
+        storedArticles = getArticles((article: Article) => article.bookmark);
         break;
       case '3':
-        storedArticles = storedArticles.filter(
-          (article: Article) => article.readAt,
+        storedArticles = getArticles(
+          (article: Article) => article.readAt !== undefined,
         );
         break;
       default:
@@ -65,7 +64,7 @@ const BankPage = () => {
         ))}
       </Flexbox>
       <Spacing size={20} />
-      <Flexbox flexDirection="column">
+      <Flexbox flexDirection="column" alignItems={'flex-start'}>
         {articles &&
           articles.map((article) => {
             const { id, title, readAt } = article;
@@ -75,6 +74,7 @@ const BankPage = () => {
                   value={id.toString()}
                   label={title}
                   checked={readAt && true}
+                  onChange={() => readArticle(id)}
                 />
                 <Spacing size={15} />
               </Fragment>

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -1,5 +1,83 @@
+import Badge from '@components/Badge';
+import Button from '@components/Button';
+import Checkbox from '@components/Checkbox';
+import Spacing from '@components/Spacing';
+import Flexbox from '@components-layout/Flexbox';
+import { CATEGORY } from '@constants/category';
+import { Fragment } from 'react';
+
 const BankPage = () => {
-  return <div>BankPage</div>;
+  const tabMenu = ['전체', '부채', '적금', '상환'];
+
+  return (
+    <div>
+      <Flexbox justifyContent={'start'}>
+        {tabMenu.map((menu) => (
+          <Button key={menu} text={menu} />
+        ))}
+      </Flexbox>
+      <Spacing size={15} />
+      <Flexbox justifyContent={'start'}>
+        {Object.values(CATEGORY).map((c) => (
+          <Badge key={c}>{c}</Badge>
+        ))}
+      </Flexbox>
+      <Spacing size={15} />
+      <Flexbox flexDirection="column">
+        {DUMMY_ARTICLES.map((article) => {
+          const { id, title, readAt } = article;
+          return (
+            <Fragment key={id}>
+              <Checkbox
+                value={id.toString()}
+                label={title}
+                checked={readAt && true}
+                onChange={(_) => null}
+              />
+              <Spacing size={15} />
+            </Fragment>
+          );
+        })}
+      </Flexbox>
+    </div>
+  );
 };
 
 export default BankPage;
+
+const DUMMY_ARTICLES: Article[] = [
+  {
+    id: 1,
+    link: 'www.naver.com',
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
+    categories: ['JavaScript', 'TypeScript'],
+    bookmark: false,
+    readAt: new Date(),
+  },
+  {
+    id: 2,
+    link: 'www.naver.com',
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
+    categories: ['DesignSystem'],
+    bookmark: false,
+    readAt: new Date(),
+  },
+  {
+    id: 3,
+    link: 'www.naver.com',
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
+    categories: ['JavaScript', 'TypeScript'],
+    bookmark: false,
+  },
+  {
+    id: 4,
+    link: 'www.naver.com',
+    title:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
+    categories: [],
+    bookmark: false,
+  },
+];

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -35,7 +35,7 @@ const BankPage = () => {
         );
         break;
       default:
-        break;
+      // filtering is NOT required when 0 (default)
     }
 
     setArticles(() => storedArticles);
@@ -58,7 +58,12 @@ const BankPage = () => {
       <Spacing size={15} />
       <Flexbox justifyContent={'start'}>
         {Object.values(CATEGORY).map((c) => (
-          <Badge key={c} outline>
+          <Badge
+            key={c}
+            filled={false}
+            toggle={true}
+            onClick={() => alert('준비중입니다!')}
+          >
             {c}
           </Badge>
         ))}
@@ -73,7 +78,7 @@ const BankPage = () => {
                 <Checkbox
                   value={id.toString()}
                   label={title}
-                  checked={readAt && true}
+                  checked={readAt === undefined ? false : true}
                   onChange={() => readArticle(id)}
                 />
                 <Spacing size={15} />

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -4,16 +4,54 @@ import Checkbox from '@components/Checkbox';
 import Spacing from '@components/Spacing';
 import Flexbox from '@components-layout/Flexbox';
 import { CATEGORY } from '@constants/category';
-import { Fragment } from 'react';
+import { Fragment, MouseEvent, useEffect, useMemo, useState } from 'react';
 
 const BankPage = () => {
-  const tabMenu = ['전체', '부채', '적금', '상환'];
+  const [articles, setArticles] = useState<Article[] | null>(null);
+  const tabMenu = useMemo(() => ['전체', '부채', '적금', '상환'], []);
+
+  useEffect(() => {
+    const storedArticles = JSON.parse(localStorage.getItem('articles') ?? '');
+    setArticles(() => storedArticles);
+  }, []);
+
+  const handleTabMenu = (e: MouseEvent<HTMLButtonElement>) => {
+    const customTabIndex = e.currentTarget.dataset.tabIndex;
+    let storedArticles = JSON.parse(localStorage.getItem('articles') ?? '');
+    switch (customTabIndex) {
+      case '1':
+        storedArticles = storedArticles.filter(
+          (article: Article) => article.readAt === undefined,
+        );
+        break;
+      case '2':
+        storedArticles = storedArticles.filter(
+          (article: Article) => article.bookmark,
+        );
+        break;
+      case '3':
+        storedArticles = storedArticles.filter(
+          (article: Article) => article.readAt,
+        );
+        break;
+      default:
+        break;
+    }
+
+    setArticles(() => storedArticles);
+  };
 
   return (
     <div>
       <Flexbox justifyContent={'start'}>
-        {tabMenu.map((menu) => (
-          <Button key={menu} text={menu} />
+        {tabMenu.map((menu, idx) => (
+          <Button
+            key={menu}
+            text={menu}
+            variant={'light'}
+            data-tab-index={idx}
+            onClick={handleTabMenu}
+          />
         ))}
       </Flexbox>
       <Spacing size={15} />
@@ -24,59 +62,23 @@ const BankPage = () => {
       </Flexbox>
       <Spacing size={15} />
       <Flexbox flexDirection="column">
-        {DUMMY_ARTICLES.map((article) => {
-          const { id, title, readAt } = article;
-          return (
-            <Fragment key={id}>
-              <Checkbox
-                value={id.toString()}
-                label={title}
-                checked={readAt && true}
-              />
-              <Spacing size={15} />
-            </Fragment>
-          );
-        })}
+        {articles &&
+          articles.map((article) => {
+            const { id, title, readAt } = article;
+            return (
+              <Fragment key={id}>
+                <Checkbox
+                  value={id.toString()}
+                  label={title}
+                  checked={readAt && true}
+                />
+                <Spacing size={15} />
+              </Fragment>
+            );
+          })}
       </Flexbox>
     </div>
   );
 };
 
 export default BankPage;
-
-const DUMMY_ARTICLES: Article[] = [
-  {
-    id: 1,
-    link: 'www.naver.com',
-    title:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
-    categories: ['JavaScript', 'TypeScript'],
-    bookmark: false,
-    readAt: new Date(),
-  },
-  {
-    id: 2,
-    link: 'www.naver.com',
-    title:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
-    categories: ['DesignSystem'],
-    bookmark: false,
-    readAt: new Date(),
-  },
-  {
-    id: 3,
-    link: 'www.naver.com',
-    title:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
-    categories: ['JavaScript', 'TypeScript'],
-    bookmark: false,
-  },
-  {
-    id: 4,
-    link: 'www.naver.com',
-    title:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore',
-    categories: [],
-    bookmark: false,
-  },
-];

--- a/src/pages/BankPage.tsx
+++ b/src/pages/BankPage.tsx
@@ -32,7 +32,6 @@ const BankPage = () => {
                 value={id.toString()}
                 label={title}
                 checked={readAt && true}
-                onChange={(_) => null}
               />
               <Spacing size={15} />
             </Fragment>


### PR DESCRIPTION
## 🤠 개요

- #11 
- 사용자가 저장한 아티클 목록을 모아서 보여주는 페이지를 구현했습니다. 

## 💫 설명

- BankPage를 구현했습니다. 

  - 화면에서 표시하는 아티클 목록을 articles 지역 상태에 저장합니다. 

  - 버튼으로 구현한 Tab 중 어떤 메뉴를 선택했는지를 selected 지역 상태에 저장합니다.  

  - 버튼을 눌렀을 때 selected 상태가 변하면서 localStorage로부터 새로운 아티클을 불러옵니다. 

- 추후에 

  - Badge에 필터링 기능을 추가합니다. 

  - Context API 와 Compound Pattern을 활용하여 Tab 컴포넌트를 구현합니다.  

## 📷 스크린샷 (Optional)

https://user-images.githubusercontent.com/31645195/224341651-232bce77-c78e-462e-8c8b-d5726bd47962.mov
